### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - develop
       # Add more branches as necessary
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/73cirdan/MMM-Formula1/security/code-scanning/2](https://github.com/73cirdan/MMM-Formula1/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so all jobs inherit least-privilege token access.  
Best single fix: add at the workflow root (after `on:` block, before `jobs:`):

- `permissions:`
- `contents: read`

This preserves current functionality (checkout and read-only CI tasks still work) while preventing accidental broader token privileges.

File to change: `.github/workflows/ci.yml`  
Region: between the trigger section and `jobs:` declaration.  
No imports/methods/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
